### PR TITLE
[TAL-696] Customize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.10-alpine
+FROM --platform=linux/amd64 python:3.10-alpine3.15
 
 ADD . /usr/src/app
 WORKDIR /usr/src/app
 
 RUN ["python", "setup.py", "install"]
+
+RUN apk --no-cache add bash
 
 CMD ["ecs"]


### PR DESCRIPTION
The image is pushed to this repository: https://hub.docker.com/repository/docker/heyjobs/ecs-deploy-multiple-images/general

This PR is related to https://github.com/heyjobs/jobseeker-portal/pull/4030

This PR adds some customizations to the Dockerfile:
1. specify platform to amd64, otherwise the default arch would be arm64, which is not supported by the current circleci host.
2. Due to this [error](https://app.circleci.com/pipelines/github/heyjobs/jobseeker-portal/28923/workflows/bc8969c4-9847-422d-b5b0-4769a6dc73ed/jobs/364905), we use alpine 3.15 instead of the latest minor version. Starting from 3.16, there has been a dependency issue against glibc with versions lower than 2.35-r0: https://github.com/sgerrand/alpine-pkg-glibc/issues/185. Our circleci aws-cli orb still uses 2.34, so until they resolve this [issue](https://github.com/CircleCI-Public/aws-cli-orb/issues/188), we might want to stay with 3.15 if we don't want to spend too much time on it.
3. install bash, as aws-cli orb uses feature from bash